### PR TITLE
get and delete can operate on endpoint root

### DIFF
--- a/consul_kv/api.py
+++ b/consul_kv/api.py
@@ -28,7 +28,7 @@ def put_kv(k, v, endpoint=DEFAULT_ENDPOINT):
         ))
 
 
-def get_kv(k, recurse=False, endpoint=DEFAULT_ENDPOINT):
+def get_kv(k=None, recurse=False, endpoint=DEFAULT_ENDPOINT):
     """
     Get the key value mapping from the distributed key value store
     :param str k: key to get
@@ -37,7 +37,7 @@ def get_kv(k, recurse=False, endpoint=DEFAULT_ENDPOINT):
     :param str endpoint: path to get the value from
     :return dict mapping: key value mapping
     """
-    url = join(endpoint, k)
+    url = join(endpoint, k) if k else endpoint
     req = request.Request(
         url=join(url, '?recurse') if recurse else url,
         method='GET'
@@ -52,7 +52,7 @@ def get_kv(k, recurse=False, endpoint=DEFAULT_ENDPOINT):
     return mapping
 
 
-def delete_kv(k, recurse=False, endpoint=DEFAULT_ENDPOINT):
+def delete_kv(k=None, recurse=False, endpoint=DEFAULT_ENDPOINT):
     """
     Delete a key from the distributed key value store
     :param str k: the key to delete
@@ -60,7 +60,7 @@ def delete_kv(k, recurse=False, endpoint=DEFAULT_ENDPOINT):
     :param str endpoint: api path to DELETE
     :return:
     """
-    url = join(endpoint, k)
+    url = join(endpoint, k) if k else endpoint
     req = request.Request(
         url=join(url, '?recurse') if recurse else url,
         method='DELETE'

--- a/tests/unit/api/test_delete_kv.py
+++ b/tests/unit/api/test_delete_kv.py
@@ -35,6 +35,14 @@ class TestDeleteKV(TestCase):
             method='DELETE'
         )
 
+    def test_delete_kv_deletes_endpoint_root_if_no_key_specified(self):
+        delete_kv()
+
+        self.request.Request.assert_called_once_with(
+            url='http://localhost:8500/v1/kv/',
+            method='DELETE'
+        )
+
     def test_delete_kv_does_request(self):
         delete_kv('some/path')
 

--- a/tests/unit/api/test_get_kv.py
+++ b/tests/unit/api/test_get_kv.py
@@ -44,6 +44,15 @@ class TestGetKV(TestCase):
             method='GET'
         )
 
+    def test_kv_gets_endpoint_root_if_no_key_specified(self):
+        get_kv()
+
+        expected_url = 'http://localhost:8500/v1/kv/'
+        self.request.Request.assert_called_once_with(
+            url=expected_url,
+            method='GET'
+        )
+
     def test_get_kv_does_request(self):
         get_kv('some/path', recurse=True)
 


### PR DESCRIPTION
if no key is specified the endpoint root should be used