### PR TITLE
Adding CAS functionality to the consul-kv library

### DIFF
--- a/consul_kv/__init__.py
+++ b/consul_kv/__init__.py
@@ -1,4 +1,4 @@
-from consul_kv.api import put_kv, get_kv, delete_kv, put_kv_txn
+from consul_kv.api import put_kv, get_kv, get_kv_cas, get_kv_meta, delete_kv, put_kv_txn
 from consul_kv.serializer import map_dictionary, dictionary_map
 from consul_kv.settings import DEFAULT_KV_ENDPOINT, DEFAULT_REQUEST_TIMEOUT
 
@@ -26,14 +26,14 @@ class Connection(object):
         )
         self.timeout = timeout or DEFAULT_REQUEST_TIMEOUT
 
-    def put(self, k, v):
+    def put(self, k, v, cas=None):
         """
         Put a key value pair at the configured endpoint
         :param str k: key to put
         :param str v: value to put
         :return None:
         """
-        return put_kv(k, v, endpoint=self.kv_endpoint, timeout=self.timeout)
+        return put_kv(k, v, cas, endpoint=self.kv_endpoint, timeout=self.timeout)
 
     def put_mapping(self, mapping):
         """
@@ -55,6 +55,18 @@ class Connection(object):
         """
         mapping = map_dictionary(dictionary)
         return self.put_mapping(mapping)
+
+    def get_cas(self, k=None, recurse=False):
+        return get_kv_cas(
+                k=k, recurse=recurse, endpoint=self.kv_endpoint,
+                timeout=self.timeout
+                )
+
+    def get_meta(self, k=None, recurse=False):
+        return get_kv_meta(
+                k=k, recurse=recurse, endpoint=self.kv_endpoint,
+                timeout=self.timeout
+                )
 
     def get(self, k=None, recurse=False):
         """

--- a/consul_kv/api.py
+++ b/consul_kv/api.py
@@ -3,14 +3,14 @@ from base64 import b64decode, b64encode
 from json import loads, dumps
 from logging import getLogger
 from os.path import join
-from urllib import request
+from urllib import request, parse
 
 from consul_kv.settings import DEFAULT_KV_ENDPOINT, DEFAULT_TXN_ENDPOINT
 
 log = getLogger(__name__)
 
 
-def put_kv(k, v, endpoint=DEFAULT_KV_ENDPOINT, timeout=socket._GLOBAL_DEFAULT_TIMEOUT):
+def put_kv(k, v, cas=None, endpoint=DEFAULT_KV_ENDPOINT, timeout=socket._GLOBAL_DEFAULT_TIMEOUT):
     """
     Put a key and value to the distributed key value store at the location path
     :param str k: the key to put
@@ -20,7 +20,15 @@ def put_kv(k, v, endpoint=DEFAULT_KV_ENDPOINT, timeout=socket._GLOBAL_DEFAULT_TI
     :return None:
     """
     encoded = str.encode(str(v))
-    url = join(endpoint, k)
+    params = dict()
+    if cas:
+        params['cas'] = cas
+
+    url = join(endpoint, k) if k else endpoint
+
+    if len(params) > 0:
+        url = "%s?%s" % (url, parse.urlencode(params))
+
     req = request.Request(
         url=url, data=encoded, method='PUT'
     )
@@ -34,7 +42,7 @@ def _mapping_to_txn_data(mapping, verb='set'):
     """
     Transform a key value mapping to a list of operations to perform
     inside the atomic transaction.
-    :param dict mapping: flat dict of key/values put
+    :param dict mapping: flat dict of key/values, or key/(value, modification-index, verb)
     :param str verb: The type of operation to perform. See the list of possibilities
     here https://www.consul.io/docs/agent/http/kv.html#txn
     :param int timeout: Seconds before timing out
@@ -43,13 +51,18 @@ def _mapping_to_txn_data(mapping, verb='set'):
     return [
         {
             'KV': {
+                'Verb': v[2],
+                'Key': k,
+                'Value': b64encode(str(v[0]).encode('utf-8')).decode('utf-8'),
+                'Index': v[1]
+            } if isinstance(v, tuple) else
+            {
                 'Verb': verb,
                 'Key': k,
                 'Value': b64encode(str(v).encode('utf-8')).decode('utf-8'),
             }
         } for k, v in mapping.items()
     ]
-
 
 def put_kv_txn(mapping, endpoint=DEFAULT_TXN_ENDPOINT, timeout=socket._GLOBAL_DEFAULT_TIMEOUT):
     """
@@ -66,6 +79,7 @@ def put_kv_txn(mapping, endpoint=DEFAULT_TXN_ENDPOINT, timeout=socket._GLOBAL_DE
     """
     txn_data = _mapping_to_txn_data(mapping, verb='set')
     data = dumps(txn_data).encode('utf-8')
+    print("%s" % data)
     req = request.Request(
         url=endpoint, data=data, method='PUT',
         headers={'Content-Type': 'application/json'}
@@ -76,33 +90,36 @@ def put_kv_txn(mapping, endpoint=DEFAULT_TXN_ENDPOINT, timeout=socket._GLOBAL_DE
         ))
 
 
-def get_kv(k=None, recurse=False, endpoint=DEFAULT_KV_ENDPOINT, timeout=socket._GLOBAL_DEFAULT_TIMEOUT):
-    """
-    Get the key value mapping from the distributed key value store
-    :param str k: key to get
-    :param bool recurse: whether or not to recurse over the path and
-    retrieve all nested values
-    :param str endpoint: API url to get the value from
-    :param int timeout: Seconds before timing out
-    :return dict mapping: key value mapping
-    """
-    url = join(endpoint, k) if k else endpoint
-    req = request.Request(
-        url=join(url, '?recurse') if recurse else url,
-        method='GET'
-    )
-    with request.urlopen(req, timeout=timeout) as r:
-        result = loads(r.read().decode('utf-8'))
-    mapping = {
-        # values are stored base64 encoded in consul, they
-        # are decoded before returned by this function.
-        r['Key']: b64decode(r['Value']).decode('utf-8')
-        if r['Value'] else None for r in result if r['Key']
-    }
-    return mapping
+def get_kv_builder(postprocessor=None):
+    def get_kv_raw(k=None, recurse=False, endpoint=DEFAULT_KV_ENDPOINT, timeout=socket._GLOBAL_DEFAULT_TIMEOUT):
+        url = join(endpoint, k) if k else endpoint
+        url = "%s?recurse"  % url if recurse else url
+        req = request.Request(
+                url=url,
+                method='GET'
+        )
+        print(" fetching %s %s" % (k, url))
+        with request.urlopen(req, timeout=timeout) as r:
+            result = loads(r.read().decode('utf-8'))
+        return postprocessor(result)
+    return get_kv_raw
 
+get_kv_meta = get_kv_builder(lambda x: x)
 
-def delete_kv(k=None, recurse=False, endpoint=DEFAULT_KV_ENDPOINT, timeout=socket._GLOBAL_DEFAULT_TIMEOUT):
+get_kv_cas = get_kv_builder(lambda x: {
+            r['Key']: (b64decode(r['Value']).decode('utf-8'), r['ModifyIndex'])
+            if r['Value'] else None for r in x if r['Key']
+          })
+
+get_kv = get_kv_builder(lambda x: {
+            # values are stored base64 encoded in consul, they
+            # are decoded before returned by this function.
+            r['Key']: b64decode(r['Value']).decode('utf-8')
+            if r['Value'] else None for r in x if r['Key']
+          })
+
+      
+def delete_kv(k=None, cas=None, recurse=False, endpoint=DEFAULT_KV_ENDPOINT, timeout=socket._GLOBAL_DEFAULT_TIMEOUT):
     """
     Delete a key from the distributed key value store
     :param str k: the key to delete
@@ -111,9 +128,18 @@ def delete_kv(k=None, recurse=False, endpoint=DEFAULT_KV_ENDPOINT, timeout=socke
     :param int timeout: Seconds before timing out
     :return:
     """
+    params = dict()
+    if cas:
+        params['cas'] = cas
+
     url = join(endpoint, k) if k else endpoint
+
+    if len(params) > 0:
+        url = "%s?%s" % (url, parse.urlencode(params))
+
+
     req = request.Request(
-        url=join(url, '?recurse') if recurse else url,
+        url="%s?recurse" % url if recurse else url,
         method='DELETE'
     )
     with request.urlopen(req, timeout=timeout) as f:

--- a/tests/unit/api/test_delete_kv.py
+++ b/tests/unit/api/test_delete_kv.py
@@ -32,7 +32,7 @@ class TestDeleteKV(TestCase):
         delete_kv('some/path', recurse=True)
 
         self.request.Request.assert_called_once_with(
-            url='http://localhost:8500/v1/kv/some/path/?recurse',
+            url='http://localhost:8500/v1/kv/some/path?recurse',
             method='DELETE'
         )
 
@@ -64,4 +64,12 @@ class TestDeleteKV(TestCase):
         delete_kv('some/path')
 
         self.assertTrue(self.log.debug)
+
+    def test_put_kv_cas(self):
+        delete_kv('some_key', cas=127)
+
+        self.request.Request.assert_called_once_with(
+            url='http://localhost:8500/v1/kv/some_key?cas=127',
+            method='DELETE'
+        )
 

--- a/tests/unit/api/test_get_kv.py
+++ b/tests/unit/api/test_get_kv.py
@@ -39,7 +39,7 @@ class TestGetKV(TestCase):
     def test_get_kv_gets_all_nested_values_if_specified(self):
         get_kv('some/path', recurse=True)
 
-        expected_url = 'http://localhost:8500/v1/kv/some/path/?recurse'
+        expected_url = 'http://localhost:8500/v1/kv/some/path?recurse'
         self.request.Request.assert_called_once_with(
             url=expected_url,
             method='GET'

--- a/tests/unit/api/test_put_kv.py
+++ b/tests/unit/api/test_put_kv.py
@@ -50,3 +50,12 @@ class TestPutKV(TestCase):
         put_kv('some_key', 'some_value')
 
         self.assertTrue(self.log.debug.called)
+
+    def test_put_kv_cas(self):
+        put_kv('some_key', 'some_value', cas=127)
+
+        self.request.Request.assert_called_once_with(
+            url='http://localhost:8500/v1/kv/some_key?cas=127',
+            data=str.encode('some_value'),
+            method='PUT'
+        )

--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -41,7 +41,7 @@ class TestConnection(TestCase):
         self.conn.put('key1', 'value1')
 
         self.put_kv.assert_called_once_with(
-            'key1', 'value1', endpoint=self.kv_endpoint,
+            'key1', 'value1', None, endpoint=self.kv_endpoint,
             timeout=10
         )
 


### PR DESCRIPTION
CAS for Consul is the ability to guard updates in the K/V against updates from multiple clients. The implementation requires for the client to pull out a version number with each data item, and supply that version number with each update or delete.
If some else has modified that piece of data then version number has changed, and update is denied.

