### PR TITLE
fix missing trailing slash regression

### DIFF
--- a/consul_kv/api.py
+++ b/consul_kv/api.py
@@ -31,8 +31,8 @@ def put_kv(
 
     url = join(endpoint, k) if k else endpoint
 
-    if len(params) > 0:
-        url = "{}?{}".format(url, urlencode(params))
+    if params:
+        url = "{}/?{}".format(url, urlencode(params))
 
     req = request.Request(
         url=url, data=encoded, method='PUT'
@@ -123,7 +123,7 @@ def get_kv_builder(postprocessor=lambda x: x):
         as defined in the specified postprocessor of the outer function.
         """
         url = join(endpoint, k) if k else endpoint
-        url = "{}?recurse".format(url) if recurse else url
+        url = "{}/?recurse".format(url) if recurse else url
         req = request.Request(
             url=url,
             method='GET'
@@ -168,14 +168,16 @@ def delete_kv(
     params = dict()
     if cas:
         params['cas'] = cas
+    if recurse:
+        params['recurse'] = recurse
 
     url = join(endpoint, k) if k else endpoint
 
-    if len(params) > 0:
-        url = "{}?{}".format(url, urlencode(params))
+    if params:
+        url = "{}/?{}".format(url, urlencode(params))
 
     req = request.Request(
-        url="%s?recurse" % url if recurse else url,
+        url=url,
         method='DELETE'
     )
     with request.urlopen(req, timeout=timeout) as f:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 setup(
     name ='consul_kv',
     packages=['consul_kv'],
-    version='0.5',
+    version='0.6',
     description='Consul KV client for Python 3',
     author='Rick van de Loo',
     author_email='rickvandeloo@gmail.com',

--- a/tests/unit/api/test_delete_kv.py
+++ b/tests/unit/api/test_delete_kv.py
@@ -32,7 +32,7 @@ class TestDeleteKV(TestCase):
         delete_kv('some/path', recurse=True)
 
         self.request.Request.assert_called_once_with(
-            url='http://localhost:8500/v1/kv/some/path?recurse',
+            url='http://localhost:8500/v1/kv/some/path/?recurse=True',
             method='DELETE'
         )
 
@@ -69,7 +69,7 @@ class TestDeleteKV(TestCase):
         delete_kv('some_key', cas=127)
 
         self.request.Request.assert_called_once_with(
-            url='http://localhost:8500/v1/kv/some_key?cas=127',
+            url='http://localhost:8500/v1/kv/some_key/?cas=127',
             method='DELETE'
         )
 

--- a/tests/unit/api/test_get_kv.py
+++ b/tests/unit/api/test_get_kv.py
@@ -39,7 +39,7 @@ class TestGetKV(TestCase):
     def test_get_kv_gets_all_nested_values_if_specified(self):
         get_kv('some/path', recurse=True)
 
-        expected_url = 'http://localhost:8500/v1/kv/some/path?recurse'
+        expected_url = 'http://localhost:8500/v1/kv/some/path/?recurse'
         self.request.Request.assert_called_once_with(
             url=expected_url,
             method='GET'

--- a/tests/unit/api/test_put_kv.py
+++ b/tests/unit/api/test_put_kv.py
@@ -55,7 +55,7 @@ class TestPutKV(TestCase):
         put_kv('some_key', 'some_value', cas=127)
 
         self.request.Request.assert_called_once_with(
-            url='http://localhost:8500/v1/kv/some_key?cas=127',
+            url='http://localhost:8500/v1/kv/some_key/?cas=127',
             data=str.encode('some_value'),
             method='PUT'
         )


### PR DESCRIPTION
looks like this trailing slash got lost in the CAS implementation.

after the cas implementation:
```
root@T1:/usr/etc/raptiformica_map# curl
http://localhost:8500/v1/kv?/recurse=true
<a href="/v1/kv/">Moved Permanently</a>.
```

before the cas implementation
```
root@T1:/usr/etc/raptiformica_map# curl
http://localhost:8500/v1/kv/?recurse=true
[{"LockIndex":0,"Key":"bla/bla","Flags":0,"Value":"blabla=="
```

the old behavior is now restored. I'm not sure if the cas query param
also requires that trailing comma though, I've assumed it does.