### PR TITLE
endpoint is without /kv

### DIFF
--- a/consul_kv/settings.py
+++ b/consul_kv/settings.py
@@ -1,5 +1,6 @@
 import socket
 
+DEFAULT_ENDPOINT = 'http://localhost:8500/v1/'
 DEFAULT_KV_ENDPOINT = 'http://localhost:8500/v1/kv/'
 DEFAULT_TXN_ENDPOINT = 'http://localhost:8500/v1/txn/'
 DEFAULT_REQUEST_TIMEOUT = socket._GLOBAL_DEFAULT_TIMEOUT


### PR DESCRIPTION
the default endpoint is now
```
DEFAULT_ENDPOINT = 'http://localhost:8500/v1/'
```

instead of
```
DEFAULT_KV_ENDPOINT = 'http://localhost:8500/v1/kv/'
```

This makes it more sensible to use conn.get_meta. otherwise you'd have
to manually specify the kv-less default endpoint and pass 'kv/' to all
kv items you'd want to interact with.