### PR TITLE
Add cas to put mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+### 0.7.3
+
+Add verb to put_dict so it can use CAS to only create the keys in the mapping if they do not exist yet.
+```
+In [2]: d = {'k1': 'v1', 'kv2': 'v2'}
+In [3]: c = Connection()
+In [4]: c.put_dict(d, verb='cas')
+In [5]: c.put_dict(d, verb='cas')
+HTTPError: HTTP Error 409: Conflict
+```
+
 ### 0.7.2
 
 Breaks compatiblity with previous versions.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,19 @@ dictionary = {
 conn.put_dict(dictionary)
 ```
 
+Atomically PUT a dictionary if the keys don't already exist
+```python
+dictionary = {
+    'a': {
+        'key': 'a_value'
+    },
+    'another': {
+        'k': 'another_value'
+    }
+}
+conn.put_dict(dictionary, verb='cas')
+```
+
 GET a key
 ```python
 conn.get('the/key')

--- a/consul_kv/__init__.py
+++ b/consul_kv/__init__.py
@@ -29,28 +29,33 @@ class Connection(object):
             timeout=self.timeout
         )
 
-    def put_mapping(self, mapping):
+    def put_mapping(self, mapping, verb='set'):
         """
         Atomically (Txn) put a key/value mapping at the configured endpoint
         :param dict mapping: dict of key/values put
+        :param str verb: The type of operation to perform. See the list of possibilities
+        here https://www.consul.io/docs/agent/http/kv.html#txn
         :return None:
         """
         return put_kv_txn(
             mapping,
             endpoint=join(self.endpoint, 'txn'),
+            verb=verb,
             timeout=self.timeout
         )
 
-    def put_dict(self, dictionary):
+    def put_dict(self, dictionary, verb='set'):
         """
         Atomically (Txn) put a dict at the configured endpoint
         :param dict dictionary: dict of nested keys and values
         {'some': {'key1': 'value1', 'key2': 'value2'} ->
         [{'some/key1': 'value1, 'some/key2': 'value2}]
+        :param str verb: The type of operation to perform. See the list of possibilities
+        here https://www.consul.io/docs/agent/http/kv.html#txn
         :return None:
         """
         mapping = map_dictionary(dictionary)
-        return self.put_mapping(mapping)
+        return self.put_mapping(mapping, verb=verb)
 
     def get_cas(self, k=None, recurse=False):
         """

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 setup(
     name ='consul_kv',
     packages=['consul_kv'],
-    version='0.7.2',
+    version='0.7.3',
     description='Consul KV client for Python 3',
     author='Rick van de Loo',
     author_email='rickvandeloo@gmail.com',

--- a/tests/unit/api/test_mapping_to_txn_data.py
+++ b/tests/unit/api/test_mapping_to_txn_data.py
@@ -42,7 +42,7 @@ class TestMappingToTxnData(TestCase):
         ret = _mapping_to_txn_data(self.mapping, verb='cas')
 
         expected_txn_data = [
-            {'KV': {'Key': 'some/key/1', 'Value': self.value_fixture1, 'Verb': 'cas'}},
-            {'KV': {'Key': 'some/key/2', 'Value': self.value_fixture2, 'Verb': 'cas'}}
+            {'Index': 0, 'KV': {'Key': 'some/key/1', 'Value': self.value_fixture1, 'Verb': 'cas'}},
+            {'Index': 0, 'KV': {'Key': 'some/key/2', 'Value': self.value_fixture2, 'Verb': 'cas'}}
         ]
         self.assertCountEqual(ret, expected_txn_data)

--- a/tests/unit/api/test_put_txn.py
+++ b/tests/unit/api/test_put_txn.py
@@ -43,6 +43,19 @@ class TestPutTxn(TestCase):
             headers={'Content-Type': 'application/json'}
         )
 
+    def test_put_kv_txn_instantiates_request_object_with_specified_verb(self):
+        put_kv_txn(self.mapping, verb='cas')
+
+        self.expected_data = json.dumps(
+            _mapping_to_txn_data(self.mapping, verb='cas')
+        ).encode('utf-8')
+        self.request.Request.assert_called_once_with(
+            url='http://localhost:8500/v1/txn',
+            data=self.expected_data,
+            method='PUT',
+            headers={'Content-Type': 'application/json'}
+        )
+
     def test_put_kv_txn_does_request(self):
         put_kv_txn(self.mapping)
 

--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -62,6 +62,17 @@ class TestConnection(TestCase):
         self.put_kv_txn.assert_called_once_with(
             self.mapping,
             endpoint=self.endpoint + 'txn',
+            verb='set',
+            timeout=10
+        )
+
+    def test_connection_put_mapping_calls_put_kv_txn_with_txn_endpoint_and_uses_cas(self):
+        self.conn.put_mapping(self.mapping, verb='cas')
+
+        self.put_kv_txn.assert_called_once_with(
+            self.mapping,
+            endpoint=self.endpoint + 'txn',
+            verb='cas',
             timeout=10
         )
 
@@ -75,7 +86,14 @@ class TestConnection(TestCase):
 
         self.conn.put_dict(self.dictionary)
 
-        put_mapping.assert_called_once_with(self.map_dictionary.return_value)
+        put_mapping.assert_called_once_with(self.map_dictionary.return_value, verb='set')
+
+    def test_connection_put_dict_puts_mapping_if_keys_do_not_already_exit(self):
+        put_mapping = self.set_up_patch('consul_kv.Connection.put_mapping')
+
+        self.conn.put_dict(self.dictionary, verb='cas')
+
+        put_mapping.assert_called_once_with(self.map_dictionary.return_value, verb='cas')
 
     def test_connection_get_calls_get_kv_with_endpoint(self):
         self.conn.get('key1')


### PR DESCRIPTION
Add verb to put_dict so it can use CAS to only create the keys in the mapping if they do not exist yet.

```bash
In [2]: d = {'k1': 'v1', 'kv2': 'v2'}
In [3]: c = Connection()
In [4]: c.put_dict(d, verb='cas')
In [5]: c.put_dict(d, verb='cas')
HTTPError: HTTP Error 409: Conflict
```